### PR TITLE
RDKB-60372: added dependency in telemetry

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bbappend
+++ b/recipes-common/telemetry/telemetry_git.bbappend
@@ -1,4 +1,4 @@
-DEPENDS += " ccsp-common-library webconfig-framework libunpriv dbus mountutils libsyswrapper rdkconfig"
+DEPENDS += " ccsp-common-library webconfig-framework libunpriv dbus mountutils libsyswrapper rdkcertconfig"
 
 LDFLAGS_append = " \
         -lprivilege \


### PR DESCRIPTION
Reason for change:Bcoz Clonning from RDK Central. it has open-source conf. it will not work for comcast device Test Procedure: Build should be passed.
Priority: P1
Risks: Low

Change-Id: I80db22a9330c0c44fb4e7a505e7be3366558b78a

(cherry picked from commit I90263718783879c79c5b0aac9d18d56b558eb03f)