### PR TITLE
RDKB-60452,RDKB-60458,RDKB-61227,RDKB-61297,RDKB-61364-OneWifi sync 09/29/25

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bb
+++ b/recipes-ccsp/ccsp/ccsp-one-wifi-libwebconfig.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=main;na
 
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'cac', '${RDKB_CCSP_ROOT_GIT}/WiFiCnxCtrl/generic;protocol=${RDK_GIT_PROTOCOL};branch=${CCSP_GIT_BRANCH};destsuffix=WiFiCnxCtrl;name=WiFiCnxCtrl', " ", d)}"
 
-SRCREV_libwebconfig = "03567834d639c78f5e56482c7c9f9336f58a8542"
+SRCREV_libwebconfig = "1907d7f451d350a801a60c8795c0d728e86d4192"
 SRCREV_WiFiCnxCtrl = "${AUTOREV}"
 SRCREV_FORMAT = "libwebconfig"
 PV = "${RDK_RELEASE}+git${SRCPV}"

--- a/recipes-ccsp/ccsp/ccsp-one-wifi.bb
+++ b/recipes-ccsp/ccsp/ccsp-one-wifi.bb
@@ -31,7 +31,7 @@ SRC_URI = "git://github.com/rdkcentral/OneWifi.git;protocol=https;branch=main;na
 
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'cac', '${RDKB_CCSP_ROOT_GIT}/WiFiCnxCtrl/generic;protocol=${RDK_GIT_PROTOCOL};branch=${CCSP_GIT_BRANCH};destsuffix=WiFiCnxCtrl;name=WiFiCnxCtrl', " ", d)}"
 
-SRCREV_OneWifi = "03567834d639c78f5e56482c7c9f9336f58a8542"
+SRCREV_OneWifi = "1907d7f451d350a801a60c8795c0d728e86d4192"
 SRCREV_WiFiCnxCtrl = "${AUTOREV}"
 SRCREV_FORMAT = "OneWifi"
 

--- a/recipes-ccsp/hal/rdk-wifi-hal.bb
+++ b/recipes-ccsp/hal/rdk-wifi-hal.bb
@@ -18,7 +18,7 @@ DEPENDS_remove_tchxb8 += "hal-platform"
 # To trigger builds, change the SRC_URI to point to forked version in github with correct BRANCH where
 # the changes are merged before creating a pull request to github.com/rdkcentral/rdk-wifi-hal
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-hal"
-SRCREV = "7c91e1263ccc35a11ac4004b3cde379694a614c4"
+SRCREV = "a04c6300e3b1931ea9812f8036ba9864f3b3caf0"
 
 ONEWIFI_CFLAGS = " -I${PKG_CONFIG_SYSROOT_DIR}/usr/include/rdk-wifi-libhostap/src \
                   -I${PKG_CONFIG_SYSROOT_DIR}/usr/include/libnl3 \

--- a/recipes-ccsp/rdk-wifi-emulator-hal/rdk-wifi-emulator-hal.bb
+++ b/recipes-ccsp/rdk-wifi-emulator-hal/rdk-wifi-emulator-hal.bb
@@ -13,7 +13,7 @@ DEPENDS += "openssl rdk-wifi-halif rdk-wifi-util cjson libpcap pkgconfig-native"
 # To trigger builds, change the SRC_URI to point to forked version in github with correct BRANCH where
 # the changes are merged before creating a pull request to github.com/rdkcentral/rdk-wifi-hal
 SRC_URI = "git://github.com/rdkcentral/rdk-wifi-hal.git;protocol=https;branch=main;name=rdk-wifi-emulator-hal"
-SRCREV = "7c91e1263ccc35a11ac4004b3cde379694a614c4"
+SRCREV = "a04c6300e3b1931ea9812f8036ba9864f3b3caf0"
 
 DEPENDS += " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'rdk-wifi-libhostap libnl broadcom-wifi', '', d)}"
 


### PR DESCRIPTION
RDKB-60452: OneWifi Sync for bb files
Reason for change: To sync bitbake files with latest OneWifi and rdk-wifi-hal latest github commit-hashes
Test Procedure: All platform builds should be successfull Risks: Low
Priority: P1

Signed-off-by: SathishKumar_Gnanasekaran <SathishKumar_Gnanasekaran@comcast.com>

Git log (oneliner) for OneWifi repo (03567834d639c78f5e56482c7c9f9336f58a8542..1907d7f451d350a801a60c8795c0d728e86d4192): ------------------------------------------------------------------------------------------------------------------------- 1907d7f RDKB-60452:WIFI_PASSWORD_FAIL" Telemetry Markers are not reporting (#615)

Git log (oneliner) for rdk-wifi-hal repo (7c91e1263ccc35a11ac4004b3cde379694a614c4..a04c6300e3b1931ea9812f8036ba9864f3b3caf0): ------------------------------------------------------------------------------------------------------------------------------ a04c630 RDKB-61297: Add RDKB_ONE_WIFI_PROD for RDKM products (#298) (#380) 962c58f RDKB-60458: Need emulator defines in rdk-wifi-hal code (#385) 59d3272 RDKB-61364 : unsupported rate print in hal (#384) 7751b8a RDKB-61227:  Facing crash reboot after triggering onewifi cases. (#319) (#382)

Change-Id: If363d39cb18cceecaa3ede93ddc07992212f827d